### PR TITLE
Slow stat tracking update FIX

### DIFF
--- a/addons/framework/statsTracking/fn_handleMissionEnd.sqf
+++ b/addons/framework/statsTracking/fn_handleMissionEnd.sqf
@@ -26,119 +26,117 @@ diag_log "[CMF] STATS - fn_handleMissionEnd - Beginning stat tracking reporting 
 numberOfPlayersInDataArray = count playersDataArray;
 playersComplete = 0;
 
-[] Spawn {
-	// Announce to players stats are updating
-	"[CMF] Stats will begin updating in 5 seconds!" remoteExec ["systemChat", 0];
+// Announce to players stats are updating
+"[CMF] Stats will begin updating in 5 seconds!" remoteExec ["systemChat", 0];
 
-	// Sleep to allow CMF_fnc_handleMissionEndLocal to propagate and get all users info into the main array
-	uiSleep 5;
+// Sleep to allow CMF_fnc_handleMissionEndLocal to propagate and get all users info into the main array
+uiSleep 5;
 
-	// Update database values
-	{	
-		[_x, _y] Spawn {
-			params ["_playerUID", "_statArray"];
+// Update database values
+{	
+	[_x, _y] Spawn {
+		params ["_playerUID", "_statArray"];
 
-			// Assign variables from hashmap
-			_roleStatus				= _statArray select 0;  // Str | String of type of role selected
-			_missionsAttended 		= _statArray select 1;  // Int | Will always be 1
-			_timeAlive 				= _statArray select 2;  // Int | Time in seconds player was not a spectator
-			_tvtKills				= _statArray select 3;  // Int | PvP Kills
-			_tvtDeaths 				= _statArray select 4;  // Int | PvP Deaths
-			_coopKills				= _statArray select 5;  // Int | PvAI Kills
-			_coopDeaths				= _statArray select 6;  // Int | PvAI Deaths
-			_friendlyFireEvents		= _statArray select 7;  // Int | Dumbass friendly fired one or more friendlies, this is how many they killed	
-			_civsKilled				= _statArray select 8;  // Int | This is how many non-potato based AI a player has killed
-			_shotsFired				= _statArray select 9;  // Int | amount of shots fired by player
-			_playerLeftMidMission	= _statArray select 10; // Int | 1 == true | 0 == false	
+		// Assign variables from hashmap
+		_roleStatus				= _statArray select 0;  // Str | String of type of role selected
+		_missionsAttended 		= _statArray select 1;  // Int | Will always be 1
+		_timeAlive 				= _statArray select 2;  // Int | Time in seconds player was not a spectator
+		_tvtKills				= _statArray select 3;  // Int | PvP Kills
+		_tvtDeaths 				= _statArray select 4;  // Int | PvP Deaths
+		_coopKills				= _statArray select 5;  // Int | PvAI Kills
+		_coopDeaths				= _statArray select 6;  // Int | PvAI Deaths
+		_friendlyFireEvents		= _statArray select 7;  // Int | Dumbass friendly fired one or more friendlies, this is how many they killed	
+		_civsKilled				= _statArray select 8;  // Int | This is how many non-potato based AI a player has killed
+		_shotsFired				= _statArray select 9;  // Int | amount of shots fired by player
+		_playerLeftMidMission	= _statArray select 10; // Int | 1 == true | 0 == false	
 
-			// Log data
-			diag_log format ["[CMF] STATS - fn_handleMissionEnd - Updating stats for steamid: %1",_playerUID];
-			
-			// Update specific sql entries
-			switch _roleStatus do
-			{
-				case "inf_pl_roles":{
-					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_pl_roles = inf_pl_roles + 1 WHERE steamid = %1",_playerUID];
-				};
-				case "inf_sl_roles":{
-					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_sl_roles = inf_sl_roles + 1 WHERE steamid = %1",_playerUID];
-				};
-				case "inf_ftl_roles":{
-					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_ftl_roles = inf_ftl_roles + 1 WHERE steamid = %1",_playerUID];
-				};
-				case "inf_gi_roles":{
-					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_gi_roles = inf_gi_roles + 1 WHERE steamid = %1",_playerUID];
-				};
-				case "inf_specialty_roles":{
-					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_specialty_roles = inf_specialty_roles + 1 WHERE steamid = %1",_playerUID];
-				};
-				case "inf_medical_roles":{
-					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_medical_roles = inf_medical_roles + 1 WHERE steamid = %1",_playerUID]; 
-				};
-				case "pilot_roles":{
-					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET pilot_roles = pilot_roles + 1 WHERE steamid = %1",_playerUID]; 
-				};
-				case "tanker_roles":{
-					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET tanker_roles = tanker_roles + 1 WHERE steamid = %1",_playerUID]; 
-				};
-			}; 
-
-			uiSleep 0.05;
-
-			// Add mission attended
-			"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET missions_attended = missions_attended + 1 WHERE steamid = %1",_playerUID]; uiSleep 0.05;
-
-			// Update total time alive
-			if (_timeAlive > 0) then {
-				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET time_alive = time_alive + %1 WHERE steamid = %2",_timeAlive,_playerUID]; uiSleep 0.05;
-				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating shotsFired. Total seconds: %1",_timeAlive];
+		// Log data
+		diag_log format ["[CMF] STATS - fn_handleMissionEnd - Updating stats for steamid: %1",_playerUID];
+		
+		// Update specific sql entries
+		switch _roleStatus do
+		{
+			case "inf_pl_roles":{
+				"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_pl_roles = inf_pl_roles + 1 WHERE steamid = %1",_playerUID];
 			};
-			
-			// Update shot count
-			if (_shotsFired > 0) then {
-				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET shots_fired = shots_fired + %1 WHERE steamid = %2",_shotsFired,_playerUID]; uiSleep 0.05;
-				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating shotsFired. Count: %1",_shotsFired];
+			case "inf_sl_roles":{
+				"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_sl_roles = inf_sl_roles + 1 WHERE steamid = %1",_playerUID];
 			};
-			
-			// Update stats based on game mode, if any
-			if (_tvtKills > 0 || _tvtDeaths > 0) then {
-				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET tvt_kills = tvt_kills + %1 WHERE steamid = %2",_tvtKills,_playerUID]; uiSleep 0.05;
-				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET tvt_deaths = tvt_deaths + %1 WHERE steamid = %2",_tvtDeaths,_playerUID]; uiSleep 0.05;
-				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating TVT stats. Total kills: %1 Total deaths: %2",_tvtKills,_tvtDeaths];
+			case "inf_ftl_roles":{
+				"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_ftl_roles = inf_ftl_roles + 1 WHERE steamid = %1",_playerUID];
 			};
-			if (_coopKills > 0 || _coopDeaths > 0) then {
-				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET coop_kills = coop_kills + %1 WHERE steamid = %2",_coopKills,_playerUID]; uiSleep 0.05;
-				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET coop_deaths = coop_deaths + %1 WHERE steamid = %2",_coopDeaths,_playerUID]; uiSleep 0.05;
-				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating COOP stats. Total kills: %1 Total deaths: %2",_coopKills,_coopDeaths];
+			case "inf_gi_roles":{
+				"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_gi_roles = inf_gi_roles + 1 WHERE steamid = %1",_playerUID];
 			};
-
-			// Update friendly fires, if any
-			if (_friendlyFireEvents > 0) then {
-				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET ff_events = ff_events + %1 WHERE steamid = %2",_friendlyFireEvents,_playerUID]; uiSleep 0.05;
-				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating friendly fire events. Count: %1",_friendlyFireEvents];
+			case "inf_specialty_roles":{
+				"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_specialty_roles = inf_specialty_roles + 1 WHERE steamid = %1",_playerUID];
 			};
-
-			// Update civs killed, if any
-			if (_civsKilled > 0) then {
-				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET civs_killed = civs_killed + %1 WHERE steamid = %2",_civsKilled,_playerUID]; uiSleep 0.05;
-				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating civ kill events. Count: %1",_civsKilled];
+			case "inf_medical_roles":{
+				"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_medical_roles = inf_medical_roles + 1 WHERE steamid = %1",_playerUID]; 
 			};
-
-			// Update leave status, if left mission
-			if (_playerLeftMidMission isEqualTo 1) then {
-				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET leaves = leaves + %1 WHERE steamid = %2",_playerLeftMidMission,_playerUID]; uiSleep 0.05;
-				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Marked player as a leaver",_playerLeftMidMission];
+			case "pilot_roles":{
+				"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET pilot_roles = pilot_roles + 1 WHERE steamid = %1",_playerUID]; 
 			};
+			case "tanker_roles":{
+				"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET tanker_roles = tanker_roles + 1 WHERE steamid = %1",_playerUID]; 
+			};
+		}; 
 
-			diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating stats for steamid: %1",_playerUID];
+		uiSleep 0.05;
 
-			playersComplete = playersComplete + 1;
+		// Add mission attended
+		"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET missions_attended = missions_attended + 1 WHERE steamid = %1",_playerUID]; uiSleep 0.05;
 
-			[format ["[CMF] Player Stats Updated : %1/%2", playersComplete, numberOfPlayersInDataArray]] remoteExec ["systemChat", 0];
-
+		// Update total time alive
+		if (_timeAlive > 0) then {
+			"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET time_alive = time_alive + %1 WHERE steamid = %2",_timeAlive,_playerUID]; uiSleep 0.05;
+			diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating shotsFired. Total seconds: %1",_timeAlive];
 		};
-	} forEach playersDataArray;
-};
+		
+		// Update shot count
+		if (_shotsFired > 0) then {
+			"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET shots_fired = shots_fired + %1 WHERE steamid = %2",_shotsFired,_playerUID]; uiSleep 0.05;
+			diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating shotsFired. Count: %1",_shotsFired];
+		};
+		
+		// Update stats based on game mode, if any
+		if (_tvtKills > 0 || _tvtDeaths > 0) then {
+			"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET tvt_kills = tvt_kills + %1 WHERE steamid = %2",_tvtKills,_playerUID]; uiSleep 0.05;
+			"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET tvt_deaths = tvt_deaths + %1 WHERE steamid = %2",_tvtDeaths,_playerUID]; uiSleep 0.05;
+			diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating TVT stats. Total kills: %1 Total deaths: %2",_tvtKills,_tvtDeaths];
+		};
+		if (_coopKills > 0 || _coopDeaths > 0) then {
+			"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET coop_kills = coop_kills + %1 WHERE steamid = %2",_coopKills,_playerUID]; uiSleep 0.05;
+			"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET coop_deaths = coop_deaths + %1 WHERE steamid = %2",_coopDeaths,_playerUID]; uiSleep 0.05;
+			diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating COOP stats. Total kills: %1 Total deaths: %2",_coopKills,_coopDeaths];
+		};
+
+		// Update friendly fires, if any
+		if (_friendlyFireEvents > 0) then {
+			"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET ff_events = ff_events + %1 WHERE steamid = %2",_friendlyFireEvents,_playerUID]; uiSleep 0.05;
+			diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating friendly fire events. Count: %1",_friendlyFireEvents];
+		};
+
+		// Update civs killed, if any
+		if (_civsKilled > 0) then {
+			"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET civs_killed = civs_killed + %1 WHERE steamid = %2",_civsKilled,_playerUID]; uiSleep 0.05;
+			diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating civ kill events. Count: %1",_civsKilled];
+		};
+
+		// Update leave status, if left mission
+		if (_playerLeftMidMission isEqualTo 1) then {
+			"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET leaves = leaves + %1 WHERE steamid = %2",_playerLeftMidMission,_playerUID]; uiSleep 0.05;
+			diag_log format ["[CMF] STATS - fn_handleMissionEnd - Marked player as a leaver",_playerLeftMidMission];
+		};
+
+		diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating stats for steamid: %1",_playerUID];
+
+		playersComplete = playersComplete + 1;
+
+		[format ["[CMF] Player Stats Updated : %1/%2", playersComplete, numberOfPlayersInDataArray]] remoteExec ["systemChat", 0];
+
+	};
+} forEach playersDataArray;
 
 waitUntil {playersComplete isEqualTo numberOfPlayersInDataArray};
 

--- a/addons/framework/statsTracking/fn_handleMissionEnd.sqf
+++ b/addons/framework/statsTracking/fn_handleMissionEnd.sqf
@@ -8,7 +8,7 @@
 	N/A
 
 	Usage:
-	[] spawn CMF_fnc_handleMissionEnd;
+	[] Spawn CMF_fnc_handleMissionEnd;
 
 */
 
@@ -23,114 +23,123 @@ diag_log "[CMF] STATS - fn_handleMissionEnd - Beginning stat tracking reporting 
 // Get still alive player data
 [] remoteExec ["CMF_fnc_handleMissionEndLocal", 0];
 
-// Announce to players stats are updating
-"[CMF] Stats will begin updating in 5 seconds!" remoteExec ["systemChat", 0];
+numberOfPlayersInDataArray = count playersDataArray;
+playersComplete = 0;
 
-// Sleep to allow CMF_fnc_handleMissionEndLocal to propagate and get all users info into the main array
-uiSleep 5;
+[] Spawn {
+	// Announce to players stats are updating
+	"[CMF] Stats will begin updating in 5 seconds!" remoteExec ["systemChat", 0];
 
-_numberOfPlayersInDataArray = count playersDataArray;
+	// Sleep to allow CMF_fnc_handleMissionEndLocal to propagate and get all users info into the main array
+	uiSleep 5;
 
-// Update database values
-{	
-	// Assign variables from hashmap
-	_playerUID				= _x;           // Str | Player Steam ID
-	_roleStatus				= _y select 0;  // Str | String of type of role selected
-	_missionsAttended 		= _y select 1;  // Int | Will always be 1
-	_timeAlive 				= _y select 2;  // Int | Time in seconds player was not a spectator
-	_tvtKills				= _y select 3;  // Int | PvP Kills
-	_tvtDeaths 				= _y select 4;  // Int | PvP Deaths
-	_coopKills				= _y select 5;  // Int | PvAI Kills
-	_coopDeaths				= _y select 6;  // Int | PvAI Deaths
-	_friendlyFireEvents		= _y select 7;  // Int | Dumbass friendly fired one or more friendlies, this is how many they killed	
-	_civsKilled				= _y select 8;  // Int | This is how many non-potato based AI a player has killed
-	_shotsFired				= _y select 9;  // Int | amount of shots fired by player
-	_playerLeftMidMission	= _y select 10; // Int | 1 == true | 0 == false	
+	// Update database values
+	{	
+		[_x, _y] Spawn {
+			params ["_playerUID", "_statArray"];
 
-	// Log data
-	diag_log format ["[CMF] STATS - fn_handleMissionEnd - Updating stats for steamid: %1",_playerUID];
-	
-	// Update specific sql entries
-	switch _roleStatus do
-	{
-		case "inf_pl_roles":{
-			"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_pl_roles = inf_pl_roles + 1 WHERE steamid = %1",_playerUID];
+			// Assign variables from hashmap
+			_roleStatus				= _statArray select 0;  // Str | String of type of role selected
+			_missionsAttended 		= _statArray select 1;  // Int | Will always be 1
+			_timeAlive 				= _statArray select 2;  // Int | Time in seconds player was not a spectator
+			_tvtKills				= _statArray select 3;  // Int | PvP Kills
+			_tvtDeaths 				= _statArray select 4;  // Int | PvP Deaths
+			_coopKills				= _statArray select 5;  // Int | PvAI Kills
+			_coopDeaths				= _statArray select 6;  // Int | PvAI Deaths
+			_friendlyFireEvents		= _statArray select 7;  // Int | Dumbass friendly fired one or more friendlies, this is how many they killed	
+			_civsKilled				= _statArray select 8;  // Int | This is how many non-potato based AI a player has killed
+			_shotsFired				= _statArray select 9;  // Int | amount of shots fired by player
+			_playerLeftMidMission	= _statArray select 10; // Int | 1 == true | 0 == false	
+
+			// Log data
+			diag_log format ["[CMF] STATS - fn_handleMissionEnd - Updating stats for steamid: %1",_playerUID];
+			
+			// Update specific sql entries
+			switch _roleStatus do
+			{
+				case "inf_pl_roles":{
+					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_pl_roles = inf_pl_roles + 1 WHERE steamid = %1",_playerUID];
+				};
+				case "inf_sl_roles":{
+					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_sl_roles = inf_sl_roles + 1 WHERE steamid = %1",_playerUID];
+				};
+				case "inf_ftl_roles":{
+					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_ftl_roles = inf_ftl_roles + 1 WHERE steamid = %1",_playerUID];
+				};
+				case "inf_gi_roles":{
+					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_gi_roles = inf_gi_roles + 1 WHERE steamid = %1",_playerUID];
+				};
+				case "inf_specialty_roles":{
+					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_specialty_roles = inf_specialty_roles + 1 WHERE steamid = %1",_playerUID];
+				};
+				case "inf_medical_roles":{
+					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_medical_roles = inf_medical_roles + 1 WHERE steamid = %1",_playerUID]; 
+				};
+				case "pilot_roles":{
+					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET pilot_roles = pilot_roles + 1 WHERE steamid = %1",_playerUID]; 
+				};
+				case "tanker_roles":{
+					"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET tanker_roles = tanker_roles + 1 WHERE steamid = %1",_playerUID]; 
+				};
+			}; 
+
+			uiSleep 0.05;
+
+			// Add mission attended
+			"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET missions_attended = missions_attended + 1 WHERE steamid = %1",_playerUID]; uiSleep 0.05;
+
+			// Update total time alive
+			if (_timeAlive > 0) then {
+				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET time_alive = time_alive + %1 WHERE steamid = %2",_timeAlive,_playerUID]; uiSleep 0.05;
+				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating shotsFired. Total seconds: %1",_timeAlive];
+			};
+			
+			// Update shot count
+			if (_shotsFired > 0) then {
+				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET shots_fired = shots_fired + %1 WHERE steamid = %2",_shotsFired,_playerUID]; uiSleep 0.05;
+				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating shotsFired. Count: %1",_shotsFired];
+			};
+			
+			// Update stats based on game mode, if any
+			if (_tvtKills > 0 || _tvtDeaths > 0) then {
+				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET tvt_kills = tvt_kills + %1 WHERE steamid = %2",_tvtKills,_playerUID]; uiSleep 0.05;
+				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET tvt_deaths = tvt_deaths + %1 WHERE steamid = %2",_tvtDeaths,_playerUID]; uiSleep 0.05;
+				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating TVT stats. Total kills: %1 Total deaths: %2",_tvtKills,_tvtDeaths];
+			};
+			if (_coopKills > 0 || _coopDeaths > 0) then {
+				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET coop_kills = coop_kills + %1 WHERE steamid = %2",_coopKills,_playerUID]; uiSleep 0.05;
+				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET coop_deaths = coop_deaths + %1 WHERE steamid = %2",_coopDeaths,_playerUID]; uiSleep 0.05;
+				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating COOP stats. Total kills: %1 Total deaths: %2",_coopKills,_coopDeaths];
+			};
+
+			// Update friendly fires, if any
+			if (_friendlyFireEvents > 0) then {
+				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET ff_events = ff_events + %1 WHERE steamid = %2",_friendlyFireEvents,_playerUID]; uiSleep 0.05;
+				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating friendly fire events. Count: %1",_friendlyFireEvents];
+			};
+
+			// Update civs killed, if any
+			if (_civsKilled > 0) then {
+				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET civs_killed = civs_killed + %1 WHERE steamid = %2",_civsKilled,_playerUID]; uiSleep 0.05;
+				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating civ kill events. Count: %1",_civsKilled];
+			};
+
+			// Update leave status, if left mission
+			if (_playerLeftMidMission isEqualTo 1) then {
+				"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET leaves = leaves + %1 WHERE steamid = %2",_playerLeftMidMission,_playerUID]; uiSleep 0.05;
+				diag_log format ["[CMF] STATS - fn_handleMissionEnd - Marked player as a leaver",_playerLeftMidMission];
+			};
+
+			diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating stats for steamid: %1",_playerUID];
+
+			playersComplete = playersComplete + 1;
+
+			[format ["[CMF] Player Stats Updated : %1/%2", playersComplete, numberOfPlayersInDataArray]] remoteExec ["systemChat", 0];
+
 		};
-		case "inf_sl_roles":{
-			"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_sl_roles = inf_sl_roles + 1 WHERE steamid = %1",_playerUID];
-		};
-		case "inf_ftl_roles":{
-			"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_ftl_roles = inf_ftl_roles + 1 WHERE steamid = %1",_playerUID];
-		};
-		case "inf_gi_roles":{
-			"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_gi_roles = inf_gi_roles + 1 WHERE steamid = %1",_playerUID];
-		};
-		case "inf_specialty_roles":{
-			"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_specialty_roles = inf_specialty_roles + 1 WHERE steamid = %1",_playerUID];
-		};
-		case "inf_medical_roles":{
-			"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET inf_medical_roles = inf_medical_roles + 1 WHERE steamid = %1",_playerUID]; 
-		};
-		case "pilot_roles":{
-			"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET pilot_roles = pilot_roles + 1 WHERE steamid = %1",_playerUID]; 
-		};
-		case "tanker_roles":{
-			"extDB3" callExtension format ["0:SQL:UPDATE a3rolestats SET tanker_roles = tanker_roles + 1 WHERE steamid = %1",_playerUID]; 
-		};
-	}; 
+	} forEach playersDataArray;
+};
 
-	uiSleep 0.05;
+waitUntil {playersComplete isEqualTo numberOfPlayersInDataArray};
 
-	// Add mission attended
-	"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET missions_attended = missions_attended + 1 WHERE steamid = %1",_playerUID]; uiSleep 0.05;
-
-	// Update total time alive
-	if (_timeAlive > 0) then {
-		"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET time_alive = time_alive + %1 WHERE steamid = %2",_timeAlive,_playerUID]; uiSleep 0.05;
-		diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating shotsFired. Total seconds: %1",_timeAlive];
-	};
-	
-	// Update shot count
-	if (_shotsFired > 0) then {
-		"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET shots_fired = shots_fired + %1 WHERE steamid = %2",_shotsFired,_playerUID]; uiSleep 0.05;
-		diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating shotsFired. Count: %1",_shotsFired];
-	};
-	
-	// Update stats based on game mode, if any
-	if (_tvtKills > 0 || _tvtDeaths > 0) then {
-		"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET tvt_kills = tvt_kills + %1 WHERE steamid = %2",_tvtKills,_playerUID]; uiSleep 0.05;
-		"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET tvt_deaths = tvt_deaths + %1 WHERE steamid = %2",_tvtDeaths,_playerUID]; uiSleep 0.05;
-		diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating TVT stats. Total kills: %1 Total deaths: %2",_tvtKills,_tvtDeaths];
-	};
-	if (_coopKills > 0 || _coopDeaths > 0) then {
-		"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET coop_kills = coop_kills + %1 WHERE steamid = %2",_coopKills,_playerUID]; uiSleep 0.05;
-		"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET coop_deaths = coop_deaths + %1 WHERE steamid = %2",_coopDeaths,_playerUID]; uiSleep 0.05;
-		diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating COOP stats. Total kills: %1 Total deaths: %2",_coopKills,_coopDeaths];
-	};
-
-	// Update friendly fires, if any
-	if (_friendlyFireEvents > 0) then {
-		"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET ff_events = ff_events + %1 WHERE steamid = %2",_friendlyFireEvents,_playerUID]; uiSleep 0.05;
-		diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating friendly fire events. Count: %1",_friendlyFireEvents];
-	};
-
-	// Update civs killed, if any
-	if (_civsKilled > 0) then {
-		"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET civs_killed = civs_killed + %1 WHERE steamid = %2",_civsKilled,_playerUID]; uiSleep 0.05;
-		diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating civ kill events. Count: %1",_civsKilled];
-	};
-
-	// Update leave status, if left mission
-	if (_playerLeftMidMission isEqualTo 1) then {
-		"extDB3" callExtension format ["0:SQL:UPDATE a3stats SET leaves = leaves + %1 WHERE steamid = %2",_playerLeftMidMission,_playerUID]; uiSleep 0.05;
-		diag_log format ["[CMF] STATS - fn_handleMissionEnd - Marked player as a leaver",_playerLeftMidMission];
-	};
-
-	diag_log format ["[CMF] STATS - fn_handleMissionEnd - Finished updating stats for steamid: %1",_playerUID];
-
-	// Announce how far in we are into parsing through the hashmap, primarily for debugging and admin, but cool to show to players
-	[format ["[CMF] Player Stats Updated : %1/%2", (_forEachIndex + 1), _numberOfPlayersInDataArray]] remoteExec ["systemChat", 0];
-
-} forEach playersDataArray;
-
-"[CMF] Stats finished updating" remoteExec ["systemChat", 0];
+"[CMF] Stats finished updating!" remoteExec ["systemChat", 0];


### PR DESCRIPTION
Made Modifications so the function is now using multiple spawned threads, which *should* make it lightning-quick. It also can still be called and will hang up whatever script it was called from until all players are updated